### PR TITLE
Fix MPF file compilation

### DIFF
--- a/MPFmaster/MPFmaster.cpp
+++ b/MPFmaster/MPFmaster.cpp
@@ -2330,7 +2330,7 @@ int cmpParseACTION(char* input_line)
 
         // apply the values
 
-        act.track = stoi(param1, nullptr, 16);
+        act.track = static_cast<int>(stoul(param1, nullptr, 16));
         act.sectionID = stoi(param2);
 
         if (act.track == 0)

--- a/MPFmaster/MPFmaster.cpp
+++ b/MPFmaster/MPFmaster.cpp
@@ -2330,7 +2330,7 @@ int cmpParseACTION(char* input_line)
 
         // apply the values
 
-        act.track = static_cast<int>(stoul(param1, nullptr, 16));
+        act.track = static_cast<int32_t>(stoul(param1, nullptr, 16));
         act.sectionID = stoi(param2);
 
         if (act.track == 0)


### PR DESCRIPTION
In cmpParseACTION function, during conversion of track value, std::stoi throws exception with the argument 0xFFFFFFFF, because it's outside of signed int range.
Fixed by replacing stoi with stoul + converting that to int32_t.
That fixes MPF file compilation.